### PR TITLE
fix: 修复打包路径`VITE_PUBLIC_PATH`配置为`url`时，主题路径不完整

### DIFF
--- a/src/common/addExtractThemeLinkTag.js
+++ b/src/common/addExtractThemeLinkTag.js
@@ -33,7 +33,7 @@ export function addExtractThemeLinkTag({
           ? customThemeCssFileName(scopeName)
           : "") || scopeName
       const linkHref = `${config.base || ""}/${outputDir || config.build.assetsDir
-        }/${filename}.css`.replace(/\/+(?=\/)/g, "")
+        }/${filename}.css`.replace(/([^:])\/\/+/g, "$1/")
       const tag = {
         tag: "link",
         attrs: {

--- a/src/common/addExtractThemeLinkTag.js
+++ b/src/common/addExtractThemeLinkTag.js
@@ -33,7 +33,7 @@ export function addExtractThemeLinkTag({
           ? customThemeCssFileName(scopeName)
           : "") || scopeName
       const linkHref = `${config.base || ""}/${outputDir || config.build.assetsDir
-        }/${filename}.css`.replace(/([^:])\/\/+/g, "$1/")
+        }/${filename}.css`.replace(/(^|[^:])\/+/g, "$1/")
       const tag = {
         tag: "link",
         attrs: {


### PR DESCRIPTION
## 现象

当配置 `vite.config.ts` 的 `base` 参数值设置成**一个以斜杠结尾的域名**结尾时，正则出现错误的结果。

```ts
export default defineConfig({
    plugins: [vue()],
    base: 'https://example.com/abc/',
})
```

错误结果：

`https://` ->  `https:/`

```html
<link rel="stylesheet" href="https:/example.com/abc/assets/layout-theme-light.css" id="theme-link-tag">
```
## 原因

这个文件 `src/common/addExtractThemeLinkTag.js` 第 36 行的正则规则不太正确，只查找了两个斜杠，然后就直接替换了，没有考虑 `config.base` 是一个域名的情况。

https://github.com/pure-admin/pure-admin-theme/blob/main/src/common/addExtractThemeLinkTag.js#L36

```js
const linkHref = `${config.base || ""}/${outputDir || config.build.assetsDir
        }/${filename}.css`.replace(/\/+(?=\/)/g, "")
```
## 修复逻辑

正则替换：非冒号开始的两个连续出现的斜杠，替换成一个斜杠。

```js
replace(/(^|[^:])\/+/g, "$1/")
```

这次应该是正确的了 :joy: